### PR TITLE
Scenario 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # AT-AT skeleton
 
 [![Build Status](https://travis-ci.org/dod-ccpo/skel.svg?branch=master)](https://travis-ci.org/dod-ccpo/skel)
+
+# Prerequisites
+
+First install perlbrew (http://perlbrew.pl and a recent perl).
+
+Then, `perlbrew install-cpanm` to install cpanminus.
+
+Then `cpanm Mojolicious` to install Mojolicious.
+
+# Run the tests
+
+    ./ata test
+
+# Run the server
+
+    ./ata daemon
+

--- a/ata
+++ b/ata
@@ -60,18 +60,16 @@ app->helper(user_can => sub($c,$role) {
     return $perms{ $user }{ $role };
 });
 
+app->helper(unauthorized => sub($c) {
+    $c->render(status => 403, text => 'unauthorized');
+});
+
+# Public routes
 get '/' => sub($c) {
   $c->render;
 } => 'dashboard';
 
 get '/login';
-get '/manage_roles';
-get '/create_user';
-get '/create_task';
-get '/enter_loa';
-get '/access_cloud';
-get '/reconcile';
-get '/reports';
 
 post '/login' => sub($c) {
     unless ($c->req->param('username')) {
@@ -81,6 +79,23 @@ post '/login' => sub($c) {
     $c->session('user', $c->req->param('username') );
     $c->redirect_to('login');
 };
+
+# Private routes
+under sub($c) {
+    my $user = $c->user or return $c->unauthorized;
+    my $role = $c->current_route;
+    $c->app->log->debug("checking auth for $user to perform $role"); 
+    return $c->unauthorized unless $c->user_can($role);
+    1;
+};
+
+get '/manage_roles';
+get '/create_user';
+get '/create_task';
+get '/enter_loa';
+get '/access_cloud';
+get '/reconcile';
+get '/reports';
 
 post '/manage_roles' => sub($c) {
     for my $user ($c->users) {

--- a/ata
+++ b/ata
@@ -1,13 +1,15 @@
 #!/usr/bin/env perl
 use Mojolicious::Lite;
+use Mojo::Util qw/trim/;
 use v5.20;
 use experimental 'signatures';
 
 my @pages = qw/
 login
+select_task
+create_task
 create_user
 manage_roles
-create_task
 enter_loa
 access_cloud
 reconcile
@@ -16,8 +18,11 @@ logout
 /;
 
 my %labels = (
-    login => 'Login', create_user => "Add a new AT-AT user",
-    manage_roles => 'Manage roles', create_task => 'Create a task',
+    login => 'Login',
+    create_user => "Add a new AT-AT user",
+    manage_roles => 'Manage roles',
+    select_task => 'Select a task',
+    create_task => 'Create a task',
     enter_loa => 'Add an LOA', access_cloud => 'Access the cloud!',
     reconcile => 'Reconcile invoices', reports => 'Run reports',
     logout => 'Logout'
@@ -29,17 +34,30 @@ app->defaults(
     layout => 'default',
 );
 
-my %perms # user => role => 1
-    = (
-        brian => { manage_roles => 1, create_user => 1, cac => 1, mfa => 1 }
-    );
+# Anyone can create a task using a task number,
+# and can set up permissions for other users
+# to manage that task.
+#
+# If a task exists, it cannot be created.
+#
+# Permissions are based on task + role.
+
+my %perms;  # user => task => role => 1
+my %tasks;  # task number => description
 
 app->helper(perms => sub($c) {
     \%perms
 });
 
-app->helper(user => sub($c) {
-    $c->session('user');
+app->helper(user => sub($c) { $c->session('user'); });
+app->helper(task => sub($c) { 
+    my $task = $c->session('task') or return '';
+    return $task if exists($tasks{$task});
+    $c->session('task','');
+    return '';
+});
+app->helper(task_description => sub($c,$task) {
+    return $tasks{$task};
 });
 
 app->helper(users => sub($c) {
@@ -51,17 +69,72 @@ app->helper(roles => sub($c) {
     'cac', 'mfa'
 });
 
-app->helper(user_can => sub($c,$role) {
+# Check perms for a user
+app->helper(check_perms => sub($c, $user, $role) {
+
+    # Unchangeable
     for ($role) {
-         /login/  and return !$c->session('user');
-         /logout/ and return !!$c->session('user');
+         /login/  and return !$user;
+         /logout/ and return 1;
     }
-    my $user = $c->session('user') or return 0;
-    return $perms{ $user }{ $role };
+
+    # Defaults if no task is selected
+    my $task = $c->task;
+    unless ($task) {
+        for ($role) {
+            /create_task/ and return !!$user;
+            /select_task/ and return !!$user;
+        }
+        return 0;
+    }
+
+    # Explicitly set.
+    return 0 unless $user;
+    if (exists( $perms{ $user }{ $task }{ $role } ) ) {
+        return $perms{ $user }{ $task }{ $role }
+    }
+
+    # Fallbacks.
+    for ($role) {
+        /create_task/ and return !!$user;
+        /select_task/ and return !!$user;
+    }
+
+    return 0;
+});
+
+# Check perms for the logged in user.
+app->helper(user_can => sub($c,$role) {
+    return $c->check_perms($c->user,$role);
+});
+
+app->helper(users_tasks => sub($c) {
+    my $task_role = $perms{ $c->user } or return;
+    sort keys %$task_role;
+});
+
+app->helper(add_task => sub($c,$number,$description) {
+   $tasks{ $number } = $description;
+   $perms{ $c->user }{ $number }{ 'manage_roles' } = 1;
+   $perms{ $c->user }{ $number }{ 'create_user' } = 1;
+});
+
+app->helper(select_task => sub($c,$number) {
+    $c->app->log->debug("Switching to task $number");
+    $c->session(task => $number);
+});
+
+app->helper(error => sub($c, $msg) {
+    $c->flash(msg => $msg);
+    $c->redirect_to($c->current_route);
 });
 
 app->helper(unauthorized => sub($c) {
-    $c->render(status => 403, text => 'unauthorized');
+    $c->render(status => 403, inline => <<DONE );
+unauthorized
+<br>
+%= link_to 'home' => 'dashboard'
+DONE
 });
 
 # Public routes
@@ -70,6 +143,12 @@ get '/' => sub($c) {
 } => 'dashboard';
 
 get '/login';
+get '/logout' => sub($c) {
+    $c->session(user => '');
+    $c->session(task => '');
+    $c->session(expires => 1);
+};
+
 
 post '/login' => sub($c) {
     unless ($c->req->param('username')) {
@@ -82,6 +161,7 @@ post '/login' => sub($c) {
 
 # Private routes
 under sub($c) {
+    $c->app->log->debug( $c->dumper( \%perms ) );
     my $user = $c->user or return $c->unauthorized;
     my $role = $c->current_route;
     $c->app->log->debug("checking auth for $user to perform $role"); 
@@ -89,6 +169,9 @@ under sub($c) {
     1;
 };
 
+get '/select_task' => sub($c) {
+    $c->select_task($c->param('task')) if $c->param('task');
+};
 get '/manage_roles';
 get '/create_user';
 get '/create_task';
@@ -100,7 +183,9 @@ get '/reports';
 post '/manage_roles' => sub($c) {
     for my $user ($c->users) {
         for my $role ($c->roles) {
-            $perms{ $user }{ $role } = !!$c->param("$user\_$role");
+            app->log->debug("setting $user @{[ $c->task ]} $role to " .
+                !!$c->param("$user\_$role") );
+            $perms{ $user }{ $c->task }{ $role } = !!$c->param("$user\_$role");
         }
     }
     $c->flash(msg => "Saved changes");
@@ -108,14 +193,21 @@ post '/manage_roles' => sub($c) {
 };
 
 post '/create_user' => sub($c) {
-    my $name = $c->param('name');
-    $perms{ $name }{ 'login' } = 1;
-    $c->flash(msg => "Added user $name");
+    my $user = $c->param('name');
+    $perms{ $user }{ $c->task } = { };
+    $c->flash(msg => "Added user $user");
     $c->redirect_to('manage_roles');
 };
 
-get '/logout' => sub($c) {
-    $c->session('user','');
+post '/create_task' => sub($c) {
+    my $task_number = trim( $c->param('task_number') )
+        or return $c->error('missing task number');
+    my $task_description = trim( $c->param('task_description') )
+        or return $c->error('missing task description');
+    return "Task $task_number already exists" if exists( $tasks{ $task_number } );
+    $c->add_task( $task_number => $task_description );
+    $c->select_task($task_number);
+    $c->redirect_to('select_task');
 };
 
 app->start;

--- a/t/01-scenario-1.t
+++ b/t/01-scenario-1.t
@@ -1,0 +1,31 @@
+#!perl
+#
+use Test::More;
+use Test::Mojo;
+
+require 'ata';
+
+my $t = Test::Mojo->new;
+$t->ua->max_redirects(2);
+
+# 1. Alice directs her office to move this workload to the cloud and asks
+# Diane to finds funds (either in the existing budget ro through another
+# office), and then gives written approval to Charlie to start the process
+# (outside of AT-AT)
+
+# 2. Charlie gets an LOA and a task number associated with the JEDI
+# Cloud contract.  (outside of AT-AT)
+
+# 3. Charlie logs into AT-AT and requests a new account, using the information
+# from the task order and adds Alice and Bob as contacts and initial users
+# with permissions to manage the account.
+
+$t->get_ok('/login')->status_is(200)
+  ->post_ok('/login' => form => { username => 'charlie', 'log in with CAC' => 1 })
+  ->status_is(200)
+  ->content_like( '/charlie/' );
+
+$t->get_ok('/create_user')->status_is(200);
+
+
+done_testing;

--- a/t/01-scenario-1.t
+++ b/t/01-scenario-1.t
@@ -20,12 +20,57 @@ $t->ua->max_redirects(2);
 # from the task order and adds Alice and Bob as contacts and initial users
 # with permissions to manage the account.
 
+# a) charlie logs in
 $t->get_ok('/login')->status_is(200)
   ->post_ok('/login' => form => { username => 'charlie', 'log in with CAC' => 1 })
   ->status_is(200)
   ->content_like( '/charlie/' );
 
-$t->get_ok('/create_user')->status_is(200);
+# b) charlie adds a task number
 
+$t->get_ok('/create_task')
+  ->post_ok('/create_task' => form => {
+    task_number => 8011,
+    task_description => 'an interesting task' })
+  ->status_is(200);
+
+# c) charlie adds alice, with permission to manage roles
+# d) charlie adds bob, with permission to manage roles
+for my $who (qw/alice bob/) {
+    $t->get_ok('/create_user')
+    ->post_ok('/create_user'
+            => form => { name => $who })
+    ->status_is(200);
+    $t->get_ok('/manage_roles')
+    ->content_like('/' . $who . '/');
+
+    my %checked = $t->tx->res->dom->find('input')->map(sub {
+        ( $_->attr('name') => $_->attr('checked') )
+        })->each;
+    my $box = $who . '_manage_roles';
+    ok ! $checked{$box}, "no permission yet for $who";
+    $checked{$box} = 1;
+    $t->post_ok('/manage_roles' => form => \%checked)
+      ->status_is(200)
+      ->content_like('/Saved/');
+
+}
+
+# Ensure Alice can manage roles.
+$t->get_ok('/manage_roles');
+ok $t->tx->res->dom->at('input[name=alice_manage_roles]')->attr('checked'),
+   'Alice can manage roles';
+
+$t->get_ok('/logout')->status_is(200);
+
+# Log in as Alice, ensure we can manage roles.
+$t->get_ok('/login')->status_is(200)
+  ->post_ok('/login' => form => { username => 'alice', 'log in with CAC' => 1 });
+
+# First, select the task.
+$t->get_ok('/select_task')
+  ->get_ok('/select_task?task=8011')
+  ->get_ok('/manage_roles')
+  ->status_is(200);
 
 done_testing;

--- a/templates/create_task.html.ep
+++ b/templates/create_task.html.ep
@@ -1,2 +1,7 @@
 create task
 
+%= form_for 'create_task' => method => 'POST' => begin
+%= text_field 'task_number', placeholder => 'Task Number', class => 'w3-input';
+%= text_field 'task_description', placeholder => 'Task Description', class => 'w3-input';
+%= submit_button 'create', class => 'w3-button w3-blue-gray';
+%= end

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -14,7 +14,14 @@ html,body,h1,h2,h3,h4,h5 {font-family: "Raleway", sans-serif}
 <!-- Top container -->
 <div class="w3-bar w3-top w3-black w3-large" style="z-index:4">
   <button class="w3-bar-item w3-button w3-hide-large w3-hover-none w3-hover-text-light-grey" onclick="w3_open();"><i class="fa fa-bars"></i>  Menu</button>
-  <span class="w3-bar-item w3-left"><%= session('user') || 'not logged in' %></span>
+  <span class="w3-bar-item w3-left"><%= user() || 'not logged in' %></span>
+  <span class="w3-bar-item w3-left">
+      % if (task) {
+      Task: <%= task() %> (<%= task_description(task()) %>)
+      % } else {
+      No task order selected.
+      % }
+  </span>
   <span class="w3-bar-item w3-right">AT-AT</span>
 </div>
 

--- a/templates/manage_roles.html.ep
+++ b/templates/manage_roles.html.ep
@@ -1,4 +1,4 @@
-manage roles
+manage roles for task <%= task %> : <%= task_description( task() ) %>
 
 %= form_for 'manage_roles', method => 'POST' => begin
 
@@ -14,8 +14,8 @@ manage roles
 <th><%= $user %></th>
 % for my $role (roles()) {
     <td style='text-align:center;'>
-    % my $checked = perms->{ $user }->{ $role } || '';
-    %= check_box "$user\_$role" => ( checked => 1 ) x !!$checked;
+    % my $checked = check_perms( $user, $role );
+    %= check_box "$user\_$role" => ( checked => 1 ) x $checked;
     </td>
 % }
 </tr>

--- a/templates/select_task.html.ep
+++ b/templates/select_task.html.ep
@@ -1,0 +1,19 @@
+% my @tasks = users_tasks();
+% if (@tasks > 0) {
+Click on a task below to switch tasks:
+<ul class='w3-ul w3-border'>
+% for my $t (@tasks) {
+    <li class='<%= $t eq task() ? 'w3-blue' : 'w3-sand' %>'>
+    %= link_to url_for->query(task => $t) => begin
+        Task <%= $t %> : <%= task_description($t) %>
+    %= end
+    </li>
+% }
+</ul>
+% } else {
+<p>You do not have access to any tasks.</p>
+% }
+<br>
+%= link_to 'create_task' => begin
+Create a task
+%= end


### PR DESCRIPTION
This adds task-order-based roles to the skeleton and some tests for scenario 1.

Key concepts:
* Any user can authenticate.
* Any user can add a task number to the system, if it is not already in the system.
* Once a task (number) is added to the system, the user who created it can add roles for other users.
* Roles are specific to tasks.
* Another user who has been granted roles for a task can log in and select that task; once the task has been selected, they will have access to whatever roles have been granted to them under that task.

The test file [t/01-scenario.t](https://github.com/dod-ccpo/skel/blob/670142da82acaa6fa686c4b1a716427534fa9dd1/t/01-scenario-1.t) has a test that corresponds to the beginning of scenario 1.  The review app for this branch is here: https://skel.atat.codes/scenario_1